### PR TITLE
bugs/VS-FeatureHighlighting

### DIFF
--- a/VisualStudio.SpecFlow/Properties/Manifest.addin.xml
+++ b/VisualStudio.SpecFlow/Properties/Manifest.addin.xml
@@ -35,6 +35,10 @@
         <Bundle file="Bundles/Cucumber.sublime-package" />
     </Extension>
 
+    <Extension path="/MonoDevelop/Ide/Editor/TextMate">
+        <Repository folderPath = "Syntax" />
+    </Extension>
+
     <Extension path = "/MonoDevelop/Ide/ProjectTemplates">
         <ProjectTemplate id = "SpecFlowProject" resource="SpecFlowProject.xpt.xml"/>
     </Extension>


### PR DESCRIPTION
* There is no highlighting in feature files anymore in Visual Studio, Updated AddIn file to fix that
* Based on @SandyArmstrong 's comment in the issue here ( #18), I updated the AddIn file to include TextMate to allow enable VS syntax classification of code 
* This fix is similar to the one done here https://github.com/mhutch/MonoDevelop.MSBuildEditor/pull/28